### PR TITLE
Move actions from `make tidy` after `make gen`

### DIFF
--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -26,7 +26,6 @@ jobs:
           make clean
           make gen
           sudo chown -R $USER api/v1/koyeb
-          make tidy
       - name: test
         run: |
           make test

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,6 @@ gen: api/v1/koyeb/openapi.json
 	docker run --rm -v `pwd`:/builder koyeb/swagger-build generate --git-user-id ${GIT_USER_ID} --git-repo-id ${GIT_REPO_ID} -i /builder/api/v1/koyeb/openapi.json -g go -o /builder/api/v1/koyeb --package-name koyeb --additional-properties enumClassPrefix=true --additional-properties isGoSubmodule=true --additional-properties generateInterfaces=true
 	# Make go mod tidy ignore this directory
 	mv api/v1/koyeb/test api/v1/koyeb/_test
-
-tidy:
 	rm api/v1/koyeb/go.mod
 	rm api/v1/koyeb/go.sum
 	go mod tidy


### PR DESCRIPTION
The command `make tidy` manually removed the files api/v1/koyeb/go.mod and api/v1/koyeb/go.sum. These files need to be removed, otherwise koyeb-cli fails to import this module.