### PR TITLE
Add deep_sleep_value and light_sleep_value to sleep_idle_delay

### DIFF
--- a/api/v1/koyeb/api/openapi.yaml
+++ b/api/v1/koyeb/api/openapi.yaml
@@ -16587,12 +16587,24 @@ components:
     DeploymentScalingTargetSleepIdleDelay:
       example:
         value: 1
+        deep_sleep_value: 600
+        light_sleep_value: 180
       properties:
         value:
           description: |-
             Delay in seconds after which a service which received 0 request is scaled to 0.
             This is not configurable and must be set to 300 (5 minutes). Get in touch to
-            tune it.
+            tune it. (DEPRECATED)
+          format: int64
+          type: integer
+        deep_sleep_value:
+          description: |-
+            Delay in seconds after which a service which received 0 request is scaled to 0 (deep sleep)
+          format: int64
+          type: integer
+        light_sleep_value:
+          description: |-
+            Delay in seconds after which a service which received 0 request is scaled down to minimal resources (light sleep)
           format: int64
           type: integer
       type: object

--- a/api/v1/koyeb/docs/DeploymentScalingTargetSleepIdleDelay.md
+++ b/api/v1/koyeb/docs/DeploymentScalingTargetSleepIdleDelay.md
@@ -4,7 +4,9 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Value** | Pointer to **int64** | Delay in seconds after which a service which received 0 request is scaled to 0. This is not configurable and must be set to 300 (5 minutes). Get in touch to tune it. | [optional] 
+**Value** | Pointer to **int64** | Delay in seconds after which a service which received 0 request is scaled to 0. This is not configurable and must be set to 300 (5 minutes). Get in touch to tune it. (DEPRECATED) | [optional]
+**DeepSleepValue** | Pointer to **int64** | Delay in seconds after which a service which received 0 request is scaled to 0 (deep sleep) | [optional]
+**LightSleepValue** | Pointer to **int64** | Delay in seconds after which a service which received 0 request is scaled down to minimal resources (light sleep) | [optional] 
 
 ## Methods
 
@@ -49,6 +51,56 @@ SetValue sets Value field to given value.
 `func (o *DeploymentScalingTargetSleepIdleDelay) HasValue() bool`
 
 HasValue returns a boolean if a field has been set.
+
+### GetDeepSleepValue
+
+`func (o *DeploymentScalingTargetSleepIdleDelay) GetDeepSleepValue() int64`
+
+GetDeepSleepValue returns the DeepSleepValue field if non-nil, zero value otherwise.
+
+### GetDeepSleepValueOk
+
+`func (o *DeploymentScalingTargetSleepIdleDelay) GetDeepSleepValueOk() (*int64, bool)`
+
+GetDeepSleepValueOk returns a tuple with the DeepSleepValue field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetDeepSleepValue
+
+`func (o *DeploymentScalingTargetSleepIdleDelay) SetDeepSleepValue(v int64)`
+
+SetDeepSleepValue sets DeepSleepValue field to given value.
+
+### HasDeepSleepValue
+
+`func (o *DeploymentScalingTargetSleepIdleDelay) HasDeepSleepValue() bool`
+
+HasDeepSleepValue returns a boolean if a field has been set.
+
+### GetLightSleepValue
+
+`func (o *DeploymentScalingTargetSleepIdleDelay) GetLightSleepValue() int64`
+
+GetLightSleepValue returns the LightSleepValue field if non-nil, zero value otherwise.
+
+### GetLightSleepValueOk
+
+`func (o *DeploymentScalingTargetSleepIdleDelay) GetLightSleepValueOk() (*int64, bool)`
+
+GetLightSleepValueOk returns a tuple with the LightSleepValue field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetLightSleepValue
+
+`func (o *DeploymentScalingTargetSleepIdleDelay) SetLightSleepValue(v int64)`
+
+SetLightSleepValue sets LightSleepValue field to given value.
+
+### HasLightSleepValue
+
+`func (o *DeploymentScalingTargetSleepIdleDelay) HasLightSleepValue() bool`
+
+HasLightSleepValue returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/api/v1/koyeb/model_deployment_scaling_target_sleep_idle_delay.go
+++ b/api/v1/koyeb/model_deployment_scaling_target_sleep_idle_delay.go
@@ -16,8 +16,12 @@ import (
 
 // DeploymentScalingTargetSleepIdleDelay struct for DeploymentScalingTargetSleepIdleDelay
 type DeploymentScalingTargetSleepIdleDelay struct {
-	// Delay in seconds after which a service which received 0 request is scaled to 0. This is not configurable and must be set to 300 (5 minutes). Get in touch to tune it.
+	// Delay in seconds after which a service which received 0 request is scaled to 0. This is not configurable and must be set to 300 (5 minutes). Get in touch to tune it. (DEPRECATED)
 	Value *int64 `json:"value,omitempty"`
+	// Delay in seconds after which a service which received 0 request is scaled to 0 (deep sleep)
+	DeepSleepValue *int64 `json:"deep_sleep_value,omitempty"`
+	// Delay in seconds after which a service which received 0 request is scaled down to minimal resources (light sleep)
+	LightSleepValue *int64 `json:"light_sleep_value,omitempty"`
 }
 
 // NewDeploymentScalingTargetSleepIdleDelay instantiates a new DeploymentScalingTargetSleepIdleDelay object
@@ -69,10 +73,78 @@ func (o *DeploymentScalingTargetSleepIdleDelay) SetValue(v int64) {
 	o.Value = &v
 }
 
+// GetDeepSleepValue returns the DeepSleepValue field value if set, zero value otherwise.
+func (o *DeploymentScalingTargetSleepIdleDelay) GetDeepSleepValue() int64 {
+	if o == nil || isNil(o.DeepSleepValue) {
+		var ret int64
+		return ret
+	}
+	return *o.DeepSleepValue
+}
+
+// GetDeepSleepValueOk returns a tuple with the DeepSleepValue field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *DeploymentScalingTargetSleepIdleDelay) GetDeepSleepValueOk() (*int64, bool) {
+	if o == nil || isNil(o.DeepSleepValue) {
+		return nil, false
+	}
+	return o.DeepSleepValue, true
+}
+
+// HasDeepSleepValue returns a boolean if a field has been set.
+func (o *DeploymentScalingTargetSleepIdleDelay) HasDeepSleepValue() bool {
+	if o != nil && !isNil(o.DeepSleepValue) {
+		return true
+	}
+	return false
+}
+
+// SetDeepSleepValue gets a reference to the given int64 and assigns it to the DeepSleepValue field.
+func (o *DeploymentScalingTargetSleepIdleDelay) SetDeepSleepValue(v int64) {
+	o.DeepSleepValue = &v
+}
+
+// GetLightSleepValue returns the LightSleepValue field value if set, zero value otherwise.
+func (o *DeploymentScalingTargetSleepIdleDelay) GetLightSleepValue() int64 {
+	if o == nil || isNil(o.LightSleepValue) {
+		var ret int64
+		return ret
+	}
+	return *o.LightSleepValue
+}
+
+// GetLightSleepValueOk returns a tuple with the LightSleepValue field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *DeploymentScalingTargetSleepIdleDelay) GetLightSleepValueOk() (*int64, bool) {
+	if o == nil || isNil(o.LightSleepValue) {
+		return nil, false
+	}
+	return o.LightSleepValue, true
+}
+
+// HasLightSleepValue returns a boolean if a field has been set.
+func (o *DeploymentScalingTargetSleepIdleDelay) HasLightSleepValue() bool {
+	if o != nil && !isNil(o.LightSleepValue) {
+		return true
+	}
+	return false
+}
+
+// SetLightSleepValue gets a reference to the given int64 and assigns it to the LightSleepValue field.
+func (o *DeploymentScalingTargetSleepIdleDelay) SetLightSleepValue(v int64) {
+	o.LightSleepValue = &v
+}
+
 func (o DeploymentScalingTargetSleepIdleDelay) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
 	if !isNil(o.Value) {
 		toSerialize["value"] = o.Value
+	}
+	if !isNil(o.DeepSleepValue) {
+		toSerialize["deep_sleep_value"] = o.DeepSleepValue
+	}
+	if !isNil(o.LightSleepValue) {
+		toSerialize["light_sleep_value"] = o.LightSleepValue
 	}
 	return json.Marshal(toSerialize)
 }

--- a/api/v1/koyeb/openapi.json
+++ b/api/v1/koyeb/openapi.json
@@ -15287,7 +15287,17 @@
         "value": {
           "type": "integer",
           "format": "int64",
-          "description": "Delay in seconds after which a service which received 0 request is scaled to 0.\nThis is not configurable and must be set to 300 (5 minutes). Get in touch to\ntune it."
+          "description": "Delay in seconds after which a service which received 0 request is scaled to 0.\nThis is not configurable and must be set to 300 (5 minutes). Get in touch to\ntune it. (DEPRECATED)"
+        },
+        "deep_sleep_value": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Delay in seconds after which a service which received 0 request is scaled to 0 (deep sleep)"
+        },
+        "light_sleep_value": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Delay in seconds after which a service which received 0 request is scaled down to minimal resources (light sleep)"
         }
       }
     },


### PR DESCRIPTION
The API has deprecated in `DeploymentScalingTargetSleepIdleDelay`,  `value` and is using `deep_sleep_value` and `light_sleep_value` instead. Update the api client to support these fields.

https://www.koyeb.com/docs/reference/api#tag/Deployments/operation/GetDeployment

I believe this was causing the cli `koyeb services update`  to fail because it couldn't get these fields from the api client in order to merge with the updated fields:
```
koyeb services update scratch/test-api-client --docker "docker.io/cchanhy/kortex:scale"
❌ Error while updating the service `scratch/test-api-client`: the Koyeb API returned an error 400: Validation error

🔎 Additional details
Field definition.scalings.0.targets.0: you have to specify deep sleep idle delay

🏥 How to solve the issue?
Fix the request, and try again

🕦 The original error was:
400 Bad Request
```

Confirmed:  I just rebuilt `koyeb-cli` locally with this change and it fixes the update.